### PR TITLE
Add testing data for test_automate_training

### DIFF
--- a/automate_training_config.json
+++ b/automate_training_config.json
@@ -1,0 +1,136 @@
+{
+  "command": "train",
+  "gpu": [7],
+  "log_directory": "tmp/logs",
+  "debugging": false,
+  "model_name": "unit_test",
+  "object_detection_params": {
+    "object_detection_path": null
+  },
+  "loader_parameters": {
+    "target_suffix": ["_lesion-manual"],
+    "roi_suffix": null,
+    "bids_path": "tmp/data_functional_testing/",
+    "roi_params": {
+      "suffix": null,
+      "slice_filter_roi": null
+    },
+    "contrast_params": {
+      "random_seed": 1313,
+      "training_validation": [
+        "T2w"
+      ],
+      "balance": {},
+      "testing": [
+        "T2w"
+      ],
+      "center_test": []
+    },
+    "slice_filter_params": {
+      "filter_empty_mask": false,
+      "filter_empty_input": true
+    },
+    "slice_axis": "axial",
+    "split_method": "per_patient",
+    "multichannel": false,
+    "soft_input": false
+  },
+  "split_dataset": {
+    "fname_split": null,
+    "random_seed": 1313,
+    "method": "per_patient",
+    "train_fraction": 0.66,
+    "test_fraction": 0.33,
+    "center_test": []
+  },
+  "training_parameters": {
+    "batch_size": 32,
+    "loss": {
+      "name": "DiceLoss"
+    },
+    "training_time": {
+      "num_epochs": 1,
+      "early_stopping_patience": 50,
+      "early_stopping_epsilon": 0.001
+    },
+    "scheduler": {
+      "initial_lr": 0.001,
+      "lr_scheduler": {
+        "name": "CosineAnnealingLR",
+        "base_lr": 1e-5,
+        "max_lr": 1e-2
+      }
+    },
+    "balance_samples": false,
+    "mixup_alpha": null,
+    "transfer_learning": {
+      "retrain_model": null,
+      "retrain_fraction": 1.0
+    }
+  },
+  "default_model": {
+    "name": "Unet",
+    "dropout_rate": 0.3,
+    "bn_momentum": 0.1,
+    "out_channel": 1,
+    "depth": 1
+  },
+  "FiLMedUnet": {
+    "applied": false,
+    "metadata": "contrasts",
+    "film_layers": [0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+  },
+  "missing_modality": false,
+  "attention_unet": false,
+  "mixup_bool": false,
+  "metadata": null,
+    "uncertainty": {
+        "epistemic": true,
+        "aleatoric": true,
+        "n_it": 2
+    },
+    "postprocessing": {
+        "remove_noise": {"thr": -1},
+        "keep_largest": {},
+        "binarize_prediction": {"thr": 0.5},
+        "fill_holes": {},
+        "remove_small": {"unit": "vox", "thr": 3},
+        "uncertainty": {"thr": -1, "suffix": "_unc-vox.nii.gz"}
+    },
+  "evaluation_parameters": {
+    "targetSize": {
+      "unit": "vox",
+      "thr": [
+        20,
+        100
+      ]
+    },
+    "overlap": {
+      "unit": "vox",
+      "thr": 3
+    }
+  },
+  "transformation": {
+    "Resample": {
+      "wspace": 0.75,
+      "hspace": 0.75
+    },
+    "ElasticTransform": {
+      "alpha_range": [28.0, 30.0],
+      "sigma_range": [3.5, 4.5],
+      "p": 0.1
+    },
+    "RandomAffine": {
+      "degrees": 4.6,
+      "translate": [0.03, 0.03],
+      "scale": [0.98, 1]
+    },
+    "CenterCrop":{
+       "size": [128, 128],
+       "preprocessing": true},
+    "NumpyToTensor": {},
+    "NormalizeInstance": {
+      "applied_to": ["im"]
+    }
+  }
+}

--- a/automate_training_hyperparameter_opt.json
+++ b/automate_training_hyperparameter_opt.json
@@ -1,0 +1,5 @@
+{
+  "training_parameters": {
+    "batch_size": [2, 4]
+  }
+}


### PR DESCRIPTION
Currently the config files for test_automate_training are stored in the `ivadomed` repo, so I'm moving them here.