### PR TITLE
Update gpu to gpu_ids argument to work with refactor in ivadomed

### DIFF
--- a/automate_training_config.json
+++ b/automate_training_config.json
@@ -1,6 +1,6 @@
 {
   "command": "train",
-  "gpu": [7],
+  "gpu_ids": [7],
   "log_directory": "tmp/logs",
   "debugging": false,
   "model_name": "unit_test",


### PR DESCRIPTION
This pull request refactors the config file to use `gpu_ids` instead of `gpu`, so we need to update `automate_training_config.json`: https://github.com/ivadomed/ivadomed/pull/644