### PR TITLE
Refactor 'log_directory' and 'bids_path'

### DIFF
--- a/automate_training_config.json
+++ b/automate_training_config.json
@@ -1,7 +1,7 @@
 {
   "command": "train",
   "gpu_ids": [7],
-  "log_directory": "tmp/logs",
+  "path_output": "tmp/logs",
   "debugging": false,
   "model_name": "unit_test",
   "object_detection_params": {
@@ -10,7 +10,7 @@
   "loader_parameters": {
     "target_suffix": ["_lesion-manual"],
     "roi_suffix": null,
-    "bids_path": "tmp/data_functional_testing/",
+    "path_data": "tmp/data_functional_testing/",
     "roi_params": {
       "suffix": null,
       "slice_filter_roi": null

--- a/model_config.json
+++ b/model_config.json
@@ -1,7 +1,7 @@
 {
   "command": "train",
   "gpu": 7,
-  "log_directory": "testing_script",
+  "path_output": "testing_script",
   "debugging": false,
   "model_name": "unit_test",
   "object_detection_params": {
@@ -10,7 +10,7 @@
   "loader_parameters": {
     "target_suffix": ["_lesion-manual"],
     "roi_suffix": null,
-    "bids_path": "testing_data/",
+    "path_data": "testing_data/",
     "roi_params": {
       "suffix": null,
       "slice_filter_roi": null

--- a/model_config_test.json
+++ b/model_config_test.json
@@ -1,7 +1,7 @@
 {
   "command": "eval",
   "gpu": 0,
-  "log_directory": "testing_script",
+  "path_output": "testing_script",
   "debugging": false,
   "model_name": "model_unet_test",
   "object_detection_params": {
@@ -10,7 +10,7 @@
   "loader_parameters": {
     "target_suffix": ["_lesion-manual"],
     "roi_suffix": null,
-    "bids_path": "testing_data/",
+    "path_data": "testing_data/",
     "roi_params": {
       "suffix": null,
       "slice_filter_roi": null

--- a/temporary_results.csv
+++ b/temporary_results.csv
@@ -1,2 +1,2 @@
-,log_directory,best_training_dice,best_training_loss,best_validation_dice,best_validation_loss,test_dice
+,path_output,best_training_dice,best_training_loss,best_validation_dice,best_validation_loss,test_dice
 0,testing_script-batch_size=2,-0.00046536312783568827,-0.00046536312783568827,-0.0012548019207002574,-0.0012548019207002574,0.0008960758197644724


### PR DESCRIPTION
# Description

The following fields have been refactored in the config files, to be compatible with new changes in this [PR](https://github.com/ivadomed/ivadomed/pull/652) in ivadomed. The purpose of these changes is to encourage more uniformity within the code, by using the same naming convention for paths used by config files. The following changes have been made:

* all instances of `log_directory` are now `path_output` 
* all instance of `bids_path` are now `path_data`