### PR TITLE
Defaulting GPU ID to [0] instead of [7]

### DIFF
--- a/automate_training_config.json
+++ b/automate_training_config.json
@@ -1,6 +1,6 @@
 {
   "command": "train",
-  "gpu_ids": [7],
+  "gpu_ids": [0],
   "path_output": "tmp/logs",
   "debugging": false,
   "model_name": "unit_test",


### PR DESCRIPTION
Most GPU unit tests machines should only have a single GPU.

This is currently causing GPU based computers to fail unit tests. 