### PR TITLE
fix: GPU ID from 7 to 0 in `model_config.json`

### DIFF
--- a/model_config.json
+++ b/model_config.json
@@ -1,6 +1,6 @@
 {
   "command": "train",
-  "gpu": 7,
+  "gpu": 0,
   "path_output": "testing_script",
   "debugging": false,
   "model_name": "unit_test",


### PR DESCRIPTION
fix in reference to https://github.com/ivadomed/ivadomed/pull/1000#pullrequestreview-894623822